### PR TITLE
Bump cmake and C++ versions.

### DIFF
--- a/arduino_state_comm/CMakeLists.txt
+++ b/arduino_state_comm/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.16.3)
 project(arduino_state_comm)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/goal_selection/CMakeLists.txt
+++ b/goal_selection/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.16.3)
 project(goal_selection)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/helper_nodes/CMakeLists.txt
+++ b/helper_nodes/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.16.3)
 project(helper_nodes)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/launch/CMakeLists.txt
+++ b/launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.16.3)
 project(launch)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/navigation_params/CMakeLists.txt
+++ b/navigation_params/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.16.3)
 project(navigation_params)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/ohm_igvc_msgs/CMakeLists.txt
+++ b/ohm_igvc_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.16.3)
 project(ohm_igvc_msgs)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/ohm_igvc_srvs/CMakeLists.txt
+++ b/ohm_igvc_srvs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.16.3)
 project(ohm_igvc_srvs)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/repos.yaml
+++ b/repos.yaml
@@ -1,10 +1,10 @@
 # These are the repos to be downloaded with vcstool
 repositories:
-  include/isc_joy:
+  isc_joy:
    type: git
    url: https://github.com/iscumd/isc_joy
    version: master
-  include/robot_state_controller:
+  robot_state_controller:
    type: git
    url: https://github.com/iscumd/robot_state_controller
   include/serial:

--- a/repos.yaml
+++ b/repos.yaml
@@ -1,10 +1,10 @@
 # These are the repos to be downloaded with vcstool
 repositories:
-  isc_joy:
+  include/isc_joy:
    type: git
    url: https://github.com/iscumd/isc_joy
    version: master
-  robot_state_controller:
+  include/robot_state_controller:
    type: git
    url: https://github.com/iscumd/robot_state_controller
   include/serial:

--- a/vn300/CMakeLists.txt
+++ b/vn300/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.16.3)
 project(vn300)
 
 ## Add support for C++11, supported in ROS Kinetic and newer
-add_definitions(-std=c++11)
+add_definitions(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/white_line_detection/CMakeLists.txt
+++ b/white_line_detection/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.16.3)
 project(white_line_detection)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)


### PR DESCRIPTION
closes #12 
blocks #18 

Still compiles fine after updates using only the defualt gcc and cmake installed in ubuntu 20.04.